### PR TITLE
Add docker config w/ air

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.8"
+services:
+  auth:
+    build: ./src/auth
+    ports:
+      - "3000:3000"

--- a/src/auth/Dockerfile
+++ b/src/auth/Dockerfile
@@ -1,6 +1,8 @@
-FROM golang:alpine
+FROM golang:1.19
+
+RUN curl -sSfL https://raw.githubusercontent.com/cosmtrek/air/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+
 RUN mkdir /app
 COPY . /app
 WORKDIR /app
-RUN go build -o main . 
-CMD ["/app/main"]
+CMD ["air"]


### PR DESCRIPTION
Add docker config for local development. Includes air package to enable live-reload